### PR TITLE
remove localtime invocation from jupyter hub config

### DIFF
--- a/devops/roles/icos.exploredata/files/docker-compose.yml
+++ b/devops/roles/icos.exploredata/files/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       # Bind Docker socket on the host so we can connect to the daemon from
       # within the container
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
-      - "/etc/localtime:/etc/localtime:ro"
       - "./jupyterhub_home:/srv/jupyterhub:rw"
     ports:
       - "${HUB_PORT-4567}:8000"

--- a/devops/roles/icos.exploredata/templates/jupyterhub_config.py
+++ b/devops/roles/icos.exploredata/templates/jupyterhub_config.py
@@ -60,7 +60,6 @@ c.DockerSpawner.notebook_dir = '/home/jovyan'
 c.DockerSpawner.remove_containers = True
 c.DockerSpawner.debug = True
 c.DockerSpawner.read_only_volumes = {
-    '/etc/localtime'          : '/etc/localtime',
     '/data/stiltweb/stations' : "/data/stiltweb/stations",
     '/data/stiltweb/slots'    : "/data/stiltweb/slots",
     '/data'                   : '/data'

--- a/devops/roles/icos.jupyter/files/docker-compose.yml
+++ b/devops/roles/icos.jupyter/files/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       # Bind Docker socket on the host so we can connect to the daemon from
       # within the container
       - "/var/run/docker.sock:/var/run/docker.sock:rw"
-      - "/etc/localtime:/etc/localtime:ro"
       - "./jupyterhub_home:/srv/jupyterhub:rw"
       - "/etc/passwd:/etc/passwd:ro"
       - "/etc/shadow:/etc/shadow:ro"

--- a/devops/roles/icos.jupyter/templates/jupyterhub_config.py
+++ b/devops/roles/icos.jupyter/templates/jupyterhub_config.py
@@ -56,7 +56,6 @@ c.DockerSpawner.read_only_volumes = {
     '/etc/group'     : '/etc/group',
     '/etc/gshadow'   : '/etc/gshadow',
     '/etc/passwd'    : '/etc/passwd',
-    '/etc/localtime' : '/etc/localtime',
     '/data'          : '/data'
 }
 


### PR DESCRIPTION
Remove mounting of local time zone from Jupyter config.
This change reverts starting containers to default behavior of UTC time zone instead of Europe/Stockholm.

config files in exploredata and Jupyter are changed and the hubs restarted.