### PR TITLE
Use single-transaction mode for MySQL database backup

### DIFF
--- a/devops/roles/icos.quince/templates/quince-backup.sh
+++ b/devops/roles/icos.quince/templates/quince-backup.sh
@@ -11,7 +11,7 @@ trap 'rm -rf "$tmp"' EXIT
 cd "$tmp"
 
 # Redirect stderr to real stdout, then stdout to file, then run awk on stderr.
-mysqldump --user=quince --password=quince --hex-blob quince 2>&1 > mysql.dump \
+mysqldump --single-transaction --quick --user=quince --password=quince --hex-blob quince 2>&1 > mysql.dump \
     | awk '! /Using a password on the command line interface can be insecure./'
 
 bbclient-all create '::{now}' mysql.dump /opt/quince_filestore


### PR DESCRIPTION
This prevents the database being locked during backup, which prevented QuinCe from being used while the backup was in progress. See https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html#option_mysqldump_single-transaction