### PR TITLE
Add ICOS Cities format

### DIFF
--- a/devops/roles/icos.cpmeta/templates/application_cities_amendment.conf
+++ b/devops/roles/icos.cpmeta/templates/application_cities_amendment.conf
@@ -72,11 +72,12 @@ cpmeta{
 				]
 				uriPrefix: "https://citymeta.icos-cp.eu/resources/"
 				definitions: [
-					{ label: "atmprodcsv", format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiAtcProductTimeSer"},
 					{ label: "atmflaskprod", format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiAtcFlaskTimeSer"},
-					{ label: "etcprodcsv", format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiEtcHalfHourlyProductTimeSer"},
+					{ label: "atmprodcsv", format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiAtcProductTimeSer"},
 					{ label: "etcmulti", format: "http://meta.icos-cp.eu/ontologies/cpmeta/etcRawTimeSerMultiZip"},
+					{ label: "etcprodcsv", format: "http://meta.icos-cp.eu/ontologies/cpmeta/asciiEtcHalfHourlyProductTimeSer"},
 					{ label: "genericcsv", format: "http://meta.icos-cp.eu/ontologies/cpmeta/genericCsv"},
+					{ label: "imgzip", format: "http://meta.icos-cp.eu/ontologies/cpmeta/multiImageZip"},
 					{ label: "netcdf", format: "http://meta.icos-cp.eu/ontologies/cpmeta/netcdf"},
 					{ label: "netcdftimeser", format: "http://meta.icos-cp.eu/ontologies/cpmeta/netcdfTimeSeries"},
 					{ label: "ziparch", format: "http://meta.icos-cp.eu/ontologies/cpmeta/zipArchive"}


### PR DESCRIPTION
To enable uploading of phenocam zip files to the ICOS Cities portal, we need to define the [multiImageZip](http://meta.icos-cp.eu/ontologies/cpmeta/multiImageZip) format in the cities configuration.