### PR TITLE
Make generated BuildInfo compile when -Yexplicit-nulls is enabled

### DIFF
--- a/sbt/icoscp-sbt-deploy/build.sbt
+++ b/sbt/icoscp-sbt-deploy/build.sbt
@@ -2,7 +2,7 @@
 ThisBuild / scalaVersion := "2.12.19"
 name := "icoscp-sbt-deploy"
 organization := "se.lu.nateko.cp"
-version := "0.4.0"
+version := "0.4.1"
 
 sbtPlugin := true
 

--- a/sbt/icoscp-sbt-deploy/src/main/scala/se/lu/nateko/cp/sbtdeploy/IcosCpSbtDeployPlugin.scala
+++ b/sbt/icoscp-sbt-deploy/src/main/scala/se/lu/nateko/cp/sbtdeploy/IcosCpSbtDeployPlugin.scala
@@ -119,7 +119,7 @@ object IcosCpSbtDeployPlugin extends AutoPlugin {
 		buildInfoKeys := Seq[BuildInfoKey](name, version),
 		buildInfoPackage := cpDeployBuildInfoPackage.value,
 		buildInfoKeys ++= Seq(
-			BuildInfoKey.action("buildTime") {java.time.Instant.now()},
+			BuildInfoKey.action("buildTime") {java.time.Instant.now().toString()},
 			BuildInfoKey.action("gitHash") {
 				Process("git rev-parse HEAD").lineStream.mkString("")
 			},


### PR DESCRIPTION
stems from https://github.com/ICOS-Carbon-Portal/meta/pull/310

Currently we get the following error when trying to build an application which depends on `icos-sbt-deploy`:
```
[error] -- [E007] Type Mismatch Error: /home/ggvgc/bulk/meta/target/scala-3.3.4/src_managed/main/sbt-buildinfo/BuildInfo.scala:11:60 
[error] 11 |  val buildTime: java.time.Instant java.time.Instant.parse("2025-04-25T11:55:58.466906706Z")
[error]    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |                                     Found:    java.time.Instant | Null
[error]    |                                     Required: java.time.Instant
```

That is a result of `sbt-buildinfo` being "smart", but since `Instant.parse()` comes from java, the return type should actually be `Instant | Null`. This is solved by returning a string instead, which is fine, since our usage of the generated `BuildInfo` is to just convert it to a string anyway.
Usage in `meta`, for example: https://github.com/ICOS-Carbon-Portal/meta/blob/master/src/main/scala/se/lu/nateko/cp/meta/routes/MainRoute.scala#L77