### PR TITLE
Upload source maps to Sentry on deploy

### DIFF
--- a/sbt/icoscp-sbt-deploy/build.sbt
+++ b/sbt/icoscp-sbt-deploy/build.sbt
@@ -2,7 +2,7 @@
 ThisBuild / scalaVersion := "2.12.19"
 name := "icoscp-sbt-deploy"
 organization := "se.lu.nateko.cp"
-version := "0.4.1"
+version := "0.4.2"
 
 sbtPlugin := true
 

--- a/sbt/icoscp-sbt-deploy/src/main/scala/se/lu/nateko/cp/sbtdeploy/IcosCpSbtDeployPlugin.scala
+++ b/sbt/icoscp-sbt-deploy/src/main/scala/se/lu/nateko/cp/sbtdeploy/IcosCpSbtDeployPlugin.scala
@@ -34,6 +34,8 @@ object IcosCpSbtDeployPlugin extends AutoPlugin {
 	import AssemblyPlugin.autoImport.assembly
 	import BuildInfoPlugin.autoImport._
 
+	private val sentryUploadProp = "cp.deploy.sentryUpload"
+
 	lazy val gitChecksTask = Def.task {
 		val log = streams.value.log
 
@@ -72,7 +74,13 @@ object IcosCpSbtDeployPlugin extends AutoPlugin {
 
 		// The full path of the "fat" jarfile. The jarfile contains the
 		// entire application and this is the file we will deploy.
-		val jarPath = assembly.value.getAbsolutePath
+		val shouldUploadToSentry = (!check && inventory == "production").toString
+		System.setProperty(sentryUploadProp, shouldUploadToSentry)
+		val jarPath = try {
+			assembly.value.getAbsolutePath
+		} finally {
+			System.clearProperty(sentryUploadProp)
+		}
 
 		// The name used by Ansible to identify this core service, e.g. 'cpdata', 'cpmeta', 'cpauth'
 		val target = cpDeployTarget.value


### PR DESCRIPTION
We set the `cp.deploy.sentryUpload` property to true when deploying to production. This allows us to only upload source maps to Sentry when using the `cpDeploy to production` command.

You can see how this is used in https://github.com/ICOS-Carbon-Portal/data/pull/437