### PR TITLE
[typesense] Fix indexing bugs

### DIFF
--- a/devops/roles/icos.typesense/templates/update_documents.py
+++ b/devops/roles/icos.typesense/templates/update_documents.py
@@ -68,7 +68,7 @@ for line in documents:
 for link in links_to_check:
     if link not in links_seen:
         links_seen.append(link)
-        if link.startswith("/"): # guard for malformed links
+        if link.startswith("/"): # guard for relative links
             new_link = base_url + link[1:]
             links_to_check.append(new_link)
         else:

--- a/devops/roles/icos.typesense/templates/update_documents.py
+++ b/devops/roles/icos.typesense/templates/update_documents.py
@@ -68,17 +68,23 @@ for line in documents:
 for link in links_to_check:
     if link not in links_seen:
         links_seen.append(link)
-        # need to freshly index this page
-        doc_stub = {"id": url_to_id(link), "url": link}
-        doc_status = update_page(doc_stub)
-        if "status" in doc_status:
-            if doc_status["status"] == 301:
-                if doc_status["dest"] not in links_seen:
-                    links_to_check.append(doc_status["dest"])
-        elif doc_status["changed"]:
-            documents_to_update_content.append(doc_status["doc"])
-            links_to_check += doc_status["links"]
-        time.sleep(0.25)
+        if link.startswith("/"): # guard for malformed links
+            new_link = base_url + link[1:]
+            links_to_check.append(new_link)
+        else:
+            # need to freshly index this page
+            doc_stub = {"id": url_to_id(link), "url": link}
+            doc_status = update_page(doc_stub)
+            if doc_status["no_index"]: # we will not index this page, but include its links
+                links_to_check += doc_status["links"]
+            elif "status" in doc_status: # we tried to request this page and failed
+                if doc_status["status"] == 301:
+                    if doc_status["dest"] not in links_seen:
+                        links_to_check.append(doc_status["dest"])
+            elif doc_status["changed"]: # we will update the page
+                documents_to_update_content.append(doc_status["doc"])
+                links_to_check += doc_status["links"]
+            time.sleep(0.25)
 
 
 # Add analytics data

--- a/devops/roles/icos.typesense/templates/utilities.py
+++ b/devops/roles/icos.typesense/templates/utilities.py
@@ -162,11 +162,19 @@ def timestamp():
 ## Main functions for importing
 def update_page(doc, verbose=False):
     url = doc["url"]
-    updated_doc = {"id": doc["id"], "url": doc["url"], "category": get_category(doc["url"])}
-    doc_status = {"changed": False, "doc": updated_doc}
+    updated_doc = {"id": doc["id"], "url": url, "category": get_category(doc["url"])}
+    doc_status = {"changed": False, "doc": updated_doc, "no_index": False}
 
-    # return unmodified doc_status if we should not index this page
+    # return doc_status with no_index and proper links if we should not index this page
     if not index_page(url):
+        doc_status["no_index"] = True
+        resp = requests.get(url)
+        if resp.status_code != 200:
+            print(timestamp() + "[update_page] Not indexing; non-200 status (GET): " + url + " with status=" + str(head.status_code))
+            doc_status["status"] = resp.status_code
+            return doc_status
+        soup = get_soup_with_iframes(resp.text)
+        doc_status["links"] = get_links_on_page(soup, url)
         return doc_status
 
     head = requests.head(url)

--- a/devops/roles/icos.typesense/templates/utilities.py
+++ b/devops/roles/icos.typesense/templates/utilities.py
@@ -170,7 +170,7 @@ def update_page(doc, verbose=False):
         doc_status["no_index"] = True
         resp = requests.get(url)
         if resp.status_code != 200:
-            print(timestamp() + "[update_page] Not indexing; non-200 status (GET): " + url + " with status=" + str(head.status_code))
+            print(timestamp() + "[update_page] Not indexing; non-200 status (GET): " + url + " with status=" + str(resp.status_code))
             doc_status["status"] = resp.status_code
             return doc_status
         soup = get_soup_with_iframes(resp.text)


### PR DESCRIPTION
Fixes two primary bugs:
1. A malformed link has been appearing in `links_to_check`; check for this kind of relative link and then correct it.
2. Include links on non-indexed pages for indexing (e.g. links on the home page, or news index).