### PR TITLE
Update fsicos4 IP

### DIFF
--- a/devops/production.inventory/hosts.yml
+++ b/devops/production.inventory/hosts.yml
@@ -20,7 +20,7 @@ all:
     fsicos1_ip: 194.47.223.133
     fsicos2_ip: 194.47.223.139
     fsicos3_ip: 194.47.223.137
-    fsicos4_ip: 130.235.98.147
+    fsicos4_ip: 130.235.92.135
     cdb_ip: 130.235.99.237
 
     # The connection information for the rdflog database, we keep it here since
@@ -31,7 +31,7 @@ all:
 
   hosts:
     fsicos4:
-      external_ip: 130.235.98.147
+      external_ip: 130.235.92.135
 
   children:
     # ALIASES


### PR DESCRIPTION
I think `130.235.98.147` was the old IP and is not used anymore. Is this correct?