### PR TITLE
flexpart - add playbook to deploy flexpart VM on fsicos4

### DIFF
--- a/devops/production.inventory/hosts.yml
+++ b/devops/production.inventory/hosts.yml
@@ -81,6 +81,9 @@ all:
           ansible_user: fdp
         test-fs4:
           ansible_port: 60608
+        flexpart:
+          ansible_port: 60611
+          ansible_user: root
 
 
     # CDB VMS

--- a/devops/production.inventory/hosts.yml
+++ b/devops/production.inventory/hosts.yml
@@ -81,7 +81,7 @@ all:
           ansible_user: fdp
         test-fs4:
           ansible_port: 60608
-        flexpart:
+        fsicos4-flexpart:
           ansible_port: 60611
           ansible_user: root
 

--- a/devops/vm-fsicos4-flexpart.yml
+++ b/devops/vm-fsicos4-flexpart.yml
@@ -1,0 +1,28 @@
+- hosts: fsicos4
+  roles:
+    - role: icos.caddy
+      tags: caddy
+      caddy_name: flexpart4
+      caddy_conf: |
+        flexpart4.icos-cp.eu {
+            reverse_proxy 10.10.10.100:8000
+        }
+
+
+- hosts: fsicos4-flexpart
+  roles:
+    - role: icos.pve_guest
+      tags: guest
+
+    - role: icos.python3
+      tags: python3
+
+    - role: icos.docker2
+      tags: docker
+
+    - role: icos.jupyter
+      tags: jupyter
+      jupyter_hub_config:
+        image: registry.icos-cp.eu/stratos.icosbase:0.1.1
+        admin_users: "{{ vault_flexpart_admins }}"
+      jupyter_backup_enable: false


### PR DESCRIPTION
Adds the `vm-fsicos4-flexpart.yml` playbook to set up a flexpart JupyterHub VM on **fsicos4**, with a caddy proxy on the host and the `icos.pve_guest` / `python3` / `docker2` / `jupyter` roles on the VM. Also adds the `fsicos4-flexpart` host to `production.inventory`, named that way so it doesn't clash with the existing fsicos3 `flexpart` host.
