### PR TITLE
Add a command to update all the Drupal websites

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -8,10 +8,35 @@ for testing.
 
 ## Deploying Drupal websites
 
-The drupal playbook requires a `website` parameter with the short name of the website. It can be used with the justfile shim.
+The Drupal playbook requires a `website` parameter. It can be one website short name, a list of short names, or `all`.
 
-`icos play drupal -ewebsite=ac -tdrupal`
+Deploy one website:
 
-which is equivalent to
+```sh
+icos play drupal -ewebsite=ac -tdrupal
+```
 
-`ansible-playbook -i production.inventory -t drupal -e "website=ac" drupal.yml`
+Equivalent Ansible command:
+
+```sh
+ansible-playbook -i production.inventory -t drupal -e "website=ac" drupal.yml
+```
+
+Deploy several websites:
+
+```sh
+ansible-playbook -i production.inventory -t drupal -e '{"website":["fi","nl"]}' drupal.yml
+```
+
+Deploy all websites from `roles/icos.drupal/defaults/main.yml`:
+
+```sh
+ansible-playbook -i production.inventory -t drupal -e website=all drupal.yml
+```
+
+Nginx and backup tasks are opt-in only:
+
+```sh
+ansible-playbook -i production.inventory -t drupal_nginx -e website=all drupal.yml
+ansible-playbook -i production.inventory -t drupal_backup drupal.yml
+```

--- a/devops/README.md
+++ b/devops/README.md
@@ -13,7 +13,7 @@ The Drupal playbook requires a `website` parameter. It can be one website short 
 Deploy one website:
 
 ```sh
-icos play drupal -ewebsite=ac -tdrupal
+icos play drupal -e "website=ac" -t drupal -DC
 ```
 
 Equivalent Ansible command:

--- a/devops/drupal.yml
+++ b/devops/drupal.yml
@@ -21,7 +21,7 @@
 
     - name: Check that at least one website was selected
       fail:
-        msg: "website must contain at least one website"
+        msg: "variable 'website' must contain at least one website"
       when: drupal_selected_websites | length == 0
       tags: [drupal, drupal_nginx]
 

--- a/devops/drupal.yml
+++ b/devops/drupal.yml
@@ -1,3 +1,47 @@
 - hosts: fsicos2
-  roles:
-    - role: icos.drupal
+  vars_files:
+    - roles/icos.drupal/defaults/main.yml
+  tasks:
+    - name: Check that website is defined
+      fail:
+        msg: "website needs to be defined"
+      when: website is undefined
+      tags: [drupal, drupal_nginx]
+
+    - name: Check that website is a string or list
+      fail:
+        msg: "website must be one website string, a list of website strings, or 'all'"
+      when: not (website is string or website is sequence)
+      tags: [drupal, drupal_nginx]
+
+    - name: Normalize selected websites
+      set_fact:
+        drupal_selected_websites: "{{ drupal_websites if website == 'all' else ([website] if website is string else website) }}"
+      tags: [drupal, drupal_nginx]
+
+    - name: Check that at least one website was selected
+      fail:
+        msg: "website must contain at least one website"
+      when: drupal_selected_websites | length == 0
+      tags: [drupal, drupal_nginx]
+
+    - name: Check selected websites
+      fail:
+        msg: "{{ item }} is not a valid website. Valid values: {{ drupal_websites | join(', ') }}"
+      when: item is not string or item not in drupal_websites
+      loop: "{{ drupal_selected_websites }}"
+      tags: [drupal, drupal_nginx]
+
+    - name: Run Drupal role for selected websites
+      include_role:
+        name: icos.drupal
+      vars:
+        drupal_website: "{{ item }}"
+      loop: "{{ drupal_selected_websites }}"
+      tags: [drupal, drupal_nginx]
+
+    - name: Configure Drupal backups
+      include_role:
+        name: icos.drupal
+        tasks_from: backup.yml
+      tags: [never, drupal_backup]

--- a/devops/roles/icos.drupal/defaults/main.yml
+++ b/devops/roles/icos.drupal/defaults/main.yml
@@ -1,5 +1,5 @@
 drupal_version: 10.6
-drupal_websites: ["ac", "ch", "cp", "fi", "next", "nl", "no", "otc", "otctest", "se", "sites"]
+drupal_websites: ["ac", "ch", "cp", "fi", "nl", "no", "otc", "otctest", "se", "sites"]
 drupal_home: /disk/data/drupal
 drupal_modules: []
 update: false

--- a/devops/roles/icos.drupal/tasks/drupal.yml
+++ b/devops/roles/icos.drupal/tasks/drupal.yml
@@ -7,7 +7,7 @@
 - name: Pull source code from git
   git:
     repo: https://github.com/ICOS-Carbon-Portal/drupal
-    version: "{{ git_version | default('master') }}"
+    version: "{{ git_version }}"
     dest: "{{ project_dir }}"
     force: yes
 
@@ -56,10 +56,10 @@
   copy:
     src: "{{ robots_txt }}"
     dest: "{{ project_dir }}/composer/robots.txt.append"
-  when: robots_txt is defined
+  when: drupal_website_vars.robots_txt is defined
 
 - name: Enable maintenance mode
-  command: docker exec {{website}}_drupal_1 drush maint:set 1
+  command: docker exec {{ drupal_website }}_drupal_1 drush maint:set 1
   when: update | bool
 
 - name: (Re)start docker containers
@@ -69,36 +69,36 @@
     pull: always
 
 - name: Check private directory owner
-  command: docker exec {{website}}_drupal_1 stat -c '%U' /var/www/private/
+  command: docker exec {{ drupal_website }}_drupal_1 stat -c '%U' /var/www/private/
   register: private_directory_owner
   changed_when: false
 
 - name: Change private directory owner
-  command: docker exec {{website}}_drupal_1 chown -R www-data:www-data /var/www/private/
+  command: docker exec {{ drupal_website }}_drupal_1 chown -R www-data:www-data /var/www/private/
   when: private_directory_owner.stdout != "www-data"
 
 - name: Check files directory owner
-  command: docker exec {{website}}_drupal_1 stat -c '%U' /var/www/private/
+  command: docker exec {{ drupal_website }}_drupal_1 stat -c '%U' /var/www/private/
   register: files_directory_owner
   changed_when: false
 
 - name: Change files directory owner
-  command: docker exec {{website}}_drupal_1 chown -R www-data:www-data /var/www/html/sites/default/files
+  command: docker exec {{ drupal_website }}_drupal_1 chown -R www-data:www-data /var/www/html/sites/default/files
   when: files_directory_owner.stdout != "www-data"
 
 - name: Composer update
-  command: docker exec {{website}}_drupal_1 composer update
+  command: docker exec {{ drupal_website }}_drupal_1 composer update
   when: update | bool
   register: result
   changed_when: '"Package operations" in result.stderr'
 
 - name: Update database
-  command: docker exec {{website}}_drupal_1 drush updb
+  command: docker exec {{ drupal_website }}_drupal_1 drush updb
   when: update | bool
 
 - name: Disable maintenance mode
-  command: docker exec {{website}}_drupal_1 drush maint:set 0
+  command: docker exec {{ drupal_website }}_drupal_1 drush maint:set 0
   when: update | bool
 
 - name: Clear caches
-  command: docker exec {{website}}_drupal_1 drush cr
+  command: docker exec {{ drupal_website }}_drupal_1 drush cr

--- a/devops/roles/icos.drupal/tasks/main.yml
+++ b/devops/roles/icos.drupal/tasks/main.yml
@@ -1,28 +1,51 @@
-- name: Check that all parameters are defined
+---
+- name: Check selected website
   fail:
-    msg: "{{ item }} needs to be defined"
-  when: vars[item] is undefined
-  loop:
-    - website
+    msg: "{{ drupal_website | default('undefined') }} is not a valid website. Valid values: {{ drupal_websites | join(', ') }}"
+  when: drupal_website is undefined or drupal_website is not string or drupal_website not in drupal_websites
   tags: [drupal, drupal_nginx]
 
-- name: Include {{ website }} vars
-  include_vars: "{{ website }}-vars.yml"
+- name: Include {{ drupal_website }} vars
+  include_vars:
+    file: "{{ drupal_website }}-vars.yml"
+    name: drupal_website_vars
   tags: [drupal, drupal_nginx]
 
-- name: Include {{ website }} vault
-  include_vars: "{{ website }}-vault.yml"
+- name: Include {{ drupal_website }} vault
+  include_vars:
+    file: "{{ drupal_website }}-vault.yml"
+    name: drupal_website_vault
   tags: [drupal, drupal_nginx]
 
-- name: Include vars
-  include_vars: drupal.yml
-  tags: [drupal, drupal_nginx]
+- block:
+    - include_tasks:
+        file: nginx.yml
+        apply:
+          tags: drupal_nginx
+      tags: [never, drupal_nginx]
 
-- import_tasks: nginx.yml
-  tags: drupal_nginx
-
-- import_tasks: drupal.yml
-  tags: drupal
-
-- import_tasks: backup.yml
-  tags: drupal_backup
+    - include_tasks:
+        file: drupal.yml
+        apply:
+          tags: drupal
+      tags: drupal
+  vars:
+    nginx_conf_name: "{{ drupal_website_vars.nginx_conf_name }}"
+    drupal_docker_port: "{{ drupal_website_vars.drupal_docker_port }}"
+    mysql_docker_port: "{{ drupal_website_vars.mysql_docker_port }}"
+    domain: "{{ drupal_website_vars.domain }}"
+    trusted_host: "{{ drupal_website_vars.trusted_host }}"
+    ssl_domains: "{{ drupal_website_vars.ssl_domains | default([drupal_website_vars.domain]) }}"
+    drupal_modules: "{{ drupal_website_vars.drupal_modules }}"
+    robots_txt: "{{ drupal_website_vars.robots_txt | default('') }}"
+    database_name: "{{ drupal_website_vars.database_name | default('icos') }}"
+    database_user: "{{ drupal_website_vars.database_user | default('icos') }}"
+    database_prefix: "{{ drupal_website_vars.database_prefix | default('') }}"
+    git_version: "{{ drupal_website_vars.git_version | default('master') }}"
+    vault_mysql_root_password: "{{ drupal_website_vault.vault_mysql_root_password }}"
+    vault_mysql_icos_password: "{{ drupal_website_vault.vault_mysql_icos_password }}"
+    vault_hash_salt: "{{ drupal_website_vault.vault_hash_salt }}"
+    vault_drupal_sync_directory: "{{ drupal_website_vault.vault_drupal_sync_directory }}"
+    project_dir: "{{ drupal_home }}/{{ drupal_website }}/drupal"
+    certbot_domains: "{{ drupal_website_vars.ssl_domains | default([drupal_website_vars.domain]) }}"
+    certbot_conf_name: "{{ drupal_website_vars.nginx_conf_name }}"

--- a/devops/roles/icos.drupal/templates/composer.json.j2
+++ b/devops/roles/icos.drupal/templates/composer.json.j2
@@ -74,7 +74,7 @@
             "locations": {
                 "web-root": "web/"
             }
-{% if robots_txt is defined %}
+{% if drupal_website_vars.robots_txt is defined %}
             ,
             "file-mapping": {
                 "[web-root]/robots.txt": {

--- a/devops/roles/icos.drupal/templates/docker-compose.yml.j2
+++ b/devops/roles/icos.drupal/templates/docker-compose.yml.j2
@@ -7,7 +7,7 @@ services:
       - "127.0.0.1:{{ drupal_docker_port }}:80"
     volumes:
       - ../composer/composer.json:/opt/drupal/composer.json
-{% if robots_txt is defined %}
+{% if drupal_website_vars.robots_txt is defined %}
       - ../composer/robots.txt.append:/opt/drupal/robots.txt.append
 {% endif %}
       - vendor:/opt/drupal/vendor
@@ -18,7 +18,7 @@ services:
       - ../files/repo:/var/www/html/repo/:rw
       - ../files/private:/var/www/private/
       - ../config/uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
-{% if website == "cp" %}
+{% if drupal_website == "cp" %}
       - ../../RINGO:/var/www/html/sites/default/files/RINGO
     external_links:
       - restheart_restheart_1:restheart
@@ -32,8 +32,8 @@ services:
       - "127.0.0.1:{{ mysql_docker_port }}:3306"
     environment:
       MYSQL_ROOT_PASSWORD: {{ vault_mysql_root_password }}
-      MYSQL_DATABASE: {{ database_name | default("icos") }}
-      MYSQL_USER: {{ database_user | default("icos") }}
+      MYSQL_DATABASE: {{ database_name }}
+      MYSQL_USER: {{ database_user }}
       MYSQL_PASSWORD: {{ vault_mysql_icos_password }}
       # MARIADB_AUTO_UPGRADE: 1
     volumes:

--- a/devops/roles/icos.drupal/templates/env.j2
+++ b/devops/roles/icos.drupal/templates/env.j2
@@ -1,2 +1,2 @@
-COMPOSE_PROJECT_NAME={{ website }}
+COMPOSE_PROJECT_NAME={{ drupal_website }}
 COMPOSE_COMPATIBILITY=true

--- a/devops/roles/icos.drupal/templates/nginx.conf.j2
+++ b/devops/roles/icos.drupal/templates/nginx.conf.j2
@@ -4,7 +4,7 @@ server {
 
   {{ certbot_nginx_conf | indent(2) }}
 
-{% if website == "cp" %}
+{% if drupal_website == "cp" %}
   location = /license {
     return 301 https://data.icos-cp.eu/licence;
   }
@@ -44,7 +44,7 @@ server {
   }
 }
 
-{% if ssl_domains is defined and ssl_domains|length > 1 %}
+{% if ssl_domains | length > 1 %}
 server {
   listen       80;
   server_name  {{ ssl_domains | join(" ") }};

--- a/devops/roles/icos.drupal/templates/settings.php.j2
+++ b/devops/roles/icos.drupal/templates/settings.php.j2
@@ -1,11 +1,11 @@
 <?php
 
 $databases['default']['default'] = array (
-  'database' => '{{ database_name | default("icos") }}',
-  'username' => '{{ database_user | default("icos") }}',
+  'database' => '{{ database_name }}',
+  'username' => '{{ database_user }}',
   'password' => '{{ vault_mysql_icos_password }}',
-  'prefix' => '{{ database_prefix | default() }}',
-  'host' => '{{ website }}_mariadb_1',
+  'prefix' => '{{ database_prefix }}',
+  'host' => '{{ drupal_website }}_mariadb_1',
   'port' => '3306',
   'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
   'driver' => 'mysql',


### PR DESCRIPTION
The Drupal playbook always required a `website` variable to be set to deploy to one of our websites. This variable can be one of `["ac", "ch", "cp", "fi", "nl", "no", "otc", "otctest", "se", "sites"]`. From the start I was planning to have the possibility to deploy to several websites with one command as it is common that only minor updates need to be done to all of them. However, the looping over tasks didn't reset the variables, so variables set for one website were kept if the configuration of the next website didn't overwrite them. In practice, we had to run the playbook for each website separately. 

With this change, we can deploy either one website, a list, or all websites with one command. The examples were updated in `devops/README.md`. Setting the default values for all variables has also been centralized in `devops/roles/icos.drupal/tasks/main.yml`.