### PR TITLE
Make sure that Akka/Nebula stay responsive under load

### DIFF
--- a/devops/roles/icos.nebula/templates/nebula.service
+++ b/devops/roles/icos.nebula/templates/nebula.service
@@ -11,5 +11,11 @@ ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ nebula_bin_dir }}/nebula -config {{ nebula_etc_dir }}/config.yml
 Restart=always
 
+# Keep the overlay network responsive under calculation/VM load.
+Nice=-10
+CPUWeight=10000
+IOWeight=10000
+OOMScoreAdjust=-900
+
 [Install]
 WantedBy=multi-user.target

--- a/devops/roles/icos.nebula/templates/nebula.service
+++ b/devops/roles/icos.nebula/templates/nebula.service
@@ -14,6 +14,7 @@ Restart=always
 # Keep the overlay network responsive under calculation/VM load.
 Nice=-10
 CPUWeight=10000
+CPUQuota=200%
 IOWeight=10000
 OOMScoreAdjust=-900
 

--- a/devops/roles/icos.pve_guest/handlers/main.yml
+++ b/devops/roles/icos.pve_guest/handlers/main.yml
@@ -1,3 +1,7 @@
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
 - name: restart cron
   service:
     name: cron

--- a/devops/roles/icos.pve_guest/handlers/main.yml
+++ b/devops/roles/icos.pve_guest/handlers/main.yml
@@ -2,6 +2,11 @@
   systemd:
     daemon_reload: true
 
+- name: restart qemu-guest-agent
+  service:
+    name: qemu-guest-agent
+    state: restarted
+
 - name: restart cron
   service:
     name: cron

--- a/devops/roles/icos.pve_guest/tasks/setup.yml
+++ b/devops/roles/icos.pve_guest/tasks/setup.yml
@@ -11,6 +11,17 @@
     name: Europe/Stockholm
   notify: restart cron
 
+- name: Prioritize qemu guest agent
+  copy:
+    dest: /etc/systemd/system/qemu-guest-agent.service.d/priority.conf
+    content: |
+      [Service]
+      Nice=-5
+      CPUWeight=8000
+      IOWeight=8000
+      OOMScoreAdjust=-800
+  notify: reload systemd
+
 - name: Generate locale
   locale_gen:
     name: "{{ item }}"

--- a/devops/roles/icos.pve_guest/tasks/setup.yml
+++ b/devops/roles/icos.pve_guest/tasks/setup.yml
@@ -11,16 +11,25 @@
     name: Europe/Stockholm
   notify: restart cron
 
+- name: Create qemu guest agent service override directory
+  file:
+    path: /etc/systemd/system/qemu-guest-agent.service.d
+    state: directory
+    mode: "0755"
+
 - name: Prioritize qemu guest agent
   copy:
     dest: /etc/systemd/system/qemu-guest-agent.service.d/priority.conf
+    mode: "0644"
     content: |
       [Service]
       Nice=-5
       CPUWeight=8000
       IOWeight=8000
       OOMScoreAdjust=-800
-  notify: reload systemd
+  notify:
+    - reload systemd
+    - restart qemu-guest-agent
 
 - name: Generate locale
   locale_gen:

--- a/devops/roles/icos.stiltcluster/tasks/deploy.yml
+++ b/devops/roles/icos.stiltcluster/tasks/deploy.yml
@@ -12,6 +12,7 @@
   template:
     src: stiltcluster.service
     dest: /etc/systemd/system/stiltcluster.service
+  notify: restart stiltcluster
 
 # scenario 1, we retrieve stiltcluster.jar and set the stiltcluster_jar_file
 # variable temporarily.

--- a/devops/roles/icos.stiltcluster/templates/stiltcluster.service
+++ b/devops/roles/icos.stiltcluster/templates/stiltcluster.service
@@ -11,5 +11,12 @@ RestartSec=30
 WorkingDirectory={{ stiltcluster_home }}
 LimitNOFILE=65536
 
+# Keep the Akka control process responsive while STILT workers are busy.
+# The Docker/STILT calculation processes are managed separately by Docker.
+Nice=-5
+CPUWeight=5000
+IOWeight=5000
+OOMScoreAdjust=-500
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The connection to fsicos4-stiltcluster is regularly dropping when calculation are running. This is most likely due to resource limitations under load. Here we increase the Akka, Nebula, and QEMU guest agent priorities to have a better chance of them staying responsive.