### PR TITLE
Add Sentry playbook

### DIFF
--- a/devops/production.inventory/hosts.yml
+++ b/devops/production.inventory/hosts.yml
@@ -87,6 +87,9 @@ all:
         fsicos4-flexpart:
           ansible_port: 60611
           ansible_user: root
+        sentry:
+          ansible_port: 60612
+          ansible_user: root
 
 
     # CDB VMS

--- a/devops/production.inventory/nebula.yml
+++ b/devops/production.inventory/nebula.yml
@@ -63,3 +63,7 @@ nebula_hosts:
     fsicos4-wordpress:
       nebula_ip: "100.100.4.10"
       nebula_port: 60714
+
+    sentry:
+      nebula_ip: "100.100.4.11"
+      nebula_port: 60712

--- a/devops/roles/icos.sentry/README.md
+++ b/devops/roles/icos.sentry/README.md
@@ -4,8 +4,7 @@ Installs and updates Sentry self-hosted and configures cold Borg backups through
 
 ## Install/update
 
-The role keeps `/opt/sentry-self-hosted` checked out at `sentry_version` and runs Sentry's upstream `install.sh` when the checkout or managed config changes. For an explicit upgrade, change `sentry_version` and run the playbook after taking a VM snapshot and a fresh backup.
-
+The role keeps `/opt/sentry-self-hosted` checked out at `sentry_version`. It runs Sentry's upstream `install.sh` only on first install, when the checkout changes, or when `sentry_run_install=true`. For an explicit upgrade, change `sentry_version` and run the playbook after taking a VM snapshot and a fresh backup.
 
 ```bash
 icos play vm-fsicos4-sentry sentry

--- a/devops/roles/icos.sentry/README.md
+++ b/devops/roles/icos.sentry/README.md
@@ -1,0 +1,35 @@
+# icos.sentry
+
+Installs and updates Sentry self-hosted and configures cold Borg backups through `icos.bbclient2`.
+
+## Install/update
+
+The role keeps `/opt/sentry-self-hosted` checked out at `sentry_version` and runs Sentry's upstream `install.sh` when the checkout or managed config changes. For an explicit upgrade, change `sentry_version` and run the playbook after taking a VM snapshot and a fresh backup.
+
+
+```bash
+icos play vm-fsicos4-sentry sentry
+```
+
+Set `sentry_run_install=true` to force the upstream installer to run without changing the tag.
+
+## Backup
+
+`tasks/backup.yml` installs a systemd timer using `icos.bbclient2`. The backup is intentionally cold:
+
+1. Optionally runs `./scripts/backup.sh global` for a supplemental logical export.
+2. Discovers Sentry Docker volumes.
+3. Stops Sentry with `docker compose down`.
+4. Borg-backs up `/opt/sentry-self-hosted` and the Docker volume mountpoints.
+5. Starts Sentry again via a trap.
+
+The logical export is not considered sufficient for disaster recovery; Sentry self-hosted also stores state in ClickHouse, Kafka, Redis, SeaweedFS/blob storage and named Docker volumes.
+
+## Restore
+
+The backup task installs `/usr/local/sbin/sentry-borg-restore`. Run it manually with an archive name from `bbclient-all list --short`.
+
+```bash
+/opt/bbclient-sentry/bin/bbclient-all list --short
+/usr/local/sbin/sentry-borg-restore ARCHIVE_NAME
+```

--- a/devops/roles/icos.sentry/defaults/main.yml
+++ b/devops/roles/icos.sentry/defaults/main.yml
@@ -1,0 +1,28 @@
+sentry_version: "26.2.1"
+sentry_home: /opt/sentry-self-hosted
+sentry_repo: https://github.com/getsentry/self-hosted.git
+# Do not rewrite working upstream config unless explicitly requested. The
+# existing sentry VM is currently served through https://sentry.icos-cp.eu/ with
+# upstream defaults for system.url-prefix and SENTRY_BIND.
+sentry_url: https://sentry.icos-cp.eu
+sentry_bind: "9000"
+sentry_manage_url_prefix: true
+sentry_manage_bind: true
+sentry_run_install: false
+sentry_git_force: false
+sentry_report_self_hosted_issues: false
+sentry_skip_commit_check: true
+sentry_skip_user_creation: true
+sentry_admin_email: admin@local.invalid
+sentry_backup_name: sentry
+sentry_backup_remotes:
+  - icos1
+sentry_backup_hour: 2
+sentry_backup_minute: 30
+sentry_backup_keep_within: 7d
+sentry_backup_keep_daily: 30
+sentry_backup_keep_weekly: 150
+sentry_backup_create_logical_export: true
+sentry_backup_volume_prefixes:
+  - sentry-
+  - sentry-self-hosted_

--- a/devops/roles/icos.sentry/defaults/main.yml
+++ b/devops/roles/icos.sentry/defaults/main.yml
@@ -1,11 +1,11 @@
 sentry_version: "26.2.1"
 sentry_home: /opt/sentry-self-hosted
 sentry_repo: https://github.com/getsentry/self-hosted.git
-# Do not rewrite working upstream config unless explicitly requested. The
-# existing sentry VM is currently served through https://sentry.icos-cp.eu/ with
-# upstream defaults for system.url-prefix and SENTRY_BIND.
+# The canonical external URL and the current working Docker port binding.
 sentry_url: https://sentry.icos-cp.eu
-sentry_bind: "9000"
+sentry_port: 9000
+sentry_bind: "{{ sentry_port }}"
+sentry_health_url: "http://127.0.0.1:{{ sentry_port }}/_health/"
 sentry_manage_url_prefix: true
 sentry_manage_bind: true
 sentry_run_install: false

--- a/devops/roles/icos.sentry/tasks/backup.yml
+++ b/devops/roles/icos.sentry/tasks/backup.yml
@@ -1,0 +1,57 @@
+- name: Create Sentry bbclient bin directory
+  file:
+    path: "/opt/bbclient-{{ sentry_backup_name }}/bin"
+    state: directory
+    mode: "0755"
+
+- include_role:
+    name: icos.bbclient2
+    public: yes
+  vars:
+    bbclient_name: "{{ sentry_backup_name }}"
+    bbclient_home: "/opt/bbclient-{{ sentry_backup_name }}"
+    bbclient_remotes: "{{ sentry_backup_remotes }}"
+    bbclient_timer_conf: |
+      OnCalendar=*-*-* {{ '%02d' | format(sentry_backup_hour | int) }}:{{ '%02d' | format(sentry_backup_minute | int) }}:00
+      RandomizedDelaySec=30m
+    bbclient_timer_content: |
+      #!/bin/bash
+      set -Eueo pipefail
+
+      sentry_home={{ sentry_home | quote }}
+      cd "$sentry_home"
+
+      compose_up() {
+        docker compose up -d --wait
+      }
+
+      trap compose_up EXIT
+
+      {% if sentry_backup_create_logical_export %}
+      mkdir -p sentry
+      # Supplemental logical export. Disaster recovery relies on the cold Borg
+      # backup below because Sentry also stores state in ClickHouse, Kafka,
+      # Redis, SeaweedFS/blob storage and Docker volumes.
+      ./scripts/backup.sh global
+      {% endif %}
+
+      mapfile -t volume_paths < <(
+        docker volume ls --format '{{ "{{" }}.Name{{ "}}" }}' |
+        grep -E '^({{ sentry_backup_volume_prefixes | map('regex_escape') | join('|') }})' |
+        while read -r volume; do
+          docker volume inspect -f '{{ "{{" }}.Mountpoint{{ "}}" }}' "$volume"
+        done |
+        sort -u
+      )
+
+      docker compose down
+
+      {{ bbclient_all }} create --stats --verbose "::{now}" "$sentry_home" "${volume_paths[@]}"
+      {{ bbclient_all }} prune --stats --list --keep-within={{ sentry_backup_keep_within }} --keep-daily={{ sentry_backup_keep_daily }} --keep-weekly={{ sentry_backup_keep_weekly }}
+      {{ bbclient_all }} compact --verbose
+
+- name: Install Sentry restore helper
+  template:
+    src: sentry-borg-restore
+    dest: /usr/local/sbin/sentry-borg-restore
+    mode: "0750"

--- a/devops/roles/icos.sentry/tasks/main.yml
+++ b/devops/roles/icos.sentry/tasks/main.yml
@@ -1,0 +1,105 @@
+- name: Install packages required by Sentry self-hosted
+  apt:
+    update_cache: true
+    name:
+      - ca-certificates
+      - curl
+      - git
+      - gzip
+      - tar
+
+- name: Check whether Sentry is already installed
+  stat:
+    path: "{{ sentry_home }}/docker-compose.yml"
+  register: sentry_compose_file
+
+- name: Clone/update Sentry self-hosted
+  git:
+    repo: "{{ sentry_repo }}"
+    dest: "{{ sentry_home }}"
+    version: "{{ sentry_version }}"
+    depth: 1
+    force: "{{ sentry_git_force }}"
+  register: sentry_git
+
+- name: Configure Sentry URL prefix
+  lineinfile:
+    path: "{{ sentry_home }}/sentry/config.yml"
+    regexp: '^#?\s*system\.url-prefix:'
+    line: "system.url-prefix: '{{ sentry_url }}'"
+  register: sentry_config_url
+  when: sentry_manage_url_prefix
+
+- name: Keep Sentry URL prefix unchanged
+  set_fact:
+    sentry_config_url:
+      changed: false
+  when: not sentry_manage_url_prefix
+
+- name: Configure Sentry nginx bind address
+  lineinfile:
+    path: "{{ sentry_home }}/.env"
+    regexp: '^SENTRY_BIND='
+    line: "SENTRY_BIND={{ sentry_bind }}"
+    create: true
+  register: sentry_config_bind
+  when: sentry_manage_bind
+
+- name: Keep Sentry nginx bind address unchanged
+  set_fact:
+    sentry_config_bind:
+      changed: false
+  when: not sentry_manage_bind
+
+- name: Run Sentry installer for first install or requested update
+  command: >-
+    ./install.sh
+    {% if sentry_skip_user_creation %}--skip-user-creation{% endif %}
+    {% if not sentry_report_self_hosted_issues %}--no-report-self-hosted-issues{% endif %}
+    {% if sentry_skip_commit_check %}--skip-commit-check{% endif %}
+  args:
+    chdir: "{{ sentry_home }}"
+  when: >-
+    sentry_run_install or
+    not sentry_compose_file.stat.exists or
+    sentry_git.changed
+  register: sentry_install
+
+- name: Start Sentry
+  command: docker compose up -d --wait
+  args:
+    chdir: "{{ sentry_home }}"
+  changed_when: "'Started' in sentry_up.stdout or 'Created' in sentry_up.stdout or 'Recreated' in sentry_up.stdout"
+  register: sentry_up
+
+- name: Create initial admin user when password is provided
+  command: >-
+    docker compose run --rm web createuser --superuser
+    --email {{ sentry_admin_email | quote }}
+    --password {{ sentry_admin_password | quote }}
+    --no-input
+  args:
+    chdir: "{{ sentry_home }}"
+  no_log: true
+  when:
+    - sentry_admin_password is defined
+    - not sentry_compose_file.stat.exists
+
+- name: Verify Sentry health endpoint
+  uri:
+    url: http://127.0.0.1:9000/_health/
+    status_code: 200
+  register: sentry_health
+  retries: 12
+  delay: 10
+  until: sentry_health.status == 200
+
+- name: Report Sentry version
+  command: docker compose run --rm web sentry --version
+  args:
+    chdir: "{{ sentry_home }}"
+  changed_when: false
+  register: sentry_version_cmd
+
+- debug:
+    msg: "{{ sentry_version_cmd.stdout }}"

--- a/devops/roles/icos.sentry/tasks/main.yml
+++ b/devops/roles/icos.sentry/tasks/main.yml
@@ -87,7 +87,7 @@
 
 - name: Verify Sentry health endpoint
   uri:
-    url: http://127.0.0.1:9000/_health/
+    url: "{{ sentry_health_url }}"
     status_code: 200
   register: sentry_health
   retries: 12

--- a/devops/roles/icos.sentry/tasks/main.yml
+++ b/devops/roles/icos.sentry/tasks/main.yml
@@ -62,7 +62,9 @@
   when: >-
     sentry_run_install or
     not sentry_compose_file.stat.exists or
-    sentry_git.changed
+    sentry_git.changed or
+    sentry_config_url.changed or
+    sentry_config_bind.changed
   register: sentry_install
 
 - name: Start Sentry

--- a/devops/roles/icos.sentry/tasks/restore.yml
+++ b/devops/roles/icos.sentry/tasks/restore.yml
@@ -1,0 +1,6 @@
+- name: Install borg for manual restore
+  include_role:
+    name: icos.borg
+
+- name: Install bbclient configuration and restore helper
+  include_tasks: backup.yml

--- a/devops/roles/icos.sentry/templates/sentry-borg-restore
+++ b/devops/roles/icos.sentry/templates/sentry-borg-restore
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Restore Sentry self-hosted from a Borg archive created by icos.sentry.
+# Usage: sentry-borg-restore ARCHIVE_NAME
+
+set -Eueo pipefail
+
+archive=${1:-}
+if [[ -z "$archive" ]]; then
+  echo "usage: sentry-borg-restore ARCHIVE_NAME" >&2
+  echo "available archives:" >&2
+  {{ bbclient_all | default('/opt/bbclient-' ~ sentry_backup_name ~ '/bin/bbclient-all') }} list --short || true
+  exit 1
+fi
+
+sentry_home={{ sentry_home | quote }}
+restore_root=/root/sentry-restore.$(date -u +%Y%m%dT%H%M%SZ)
+mkdir -p "$restore_root"
+
+if [[ -d "$sentry_home" ]]; then
+  cd "$sentry_home"
+  docker compose down || true
+fi
+
+# Move existing Sentry install and Docker volume payloads out of the way before
+# extracting. They are kept for manual rollback until the restore is verified.
+if [[ -e "$sentry_home" ]]; then
+  mkdir -p "$restore_root/opt"
+  mv "$sentry_home" "$restore_root/sentry-self-hosted.previous"
+fi
+
+mapfile -t volume_paths < <(
+  docker volume ls --format '{{ "{{" }}.Name{{ "}}" }}' |
+  grep -E '^({{ sentry_backup_volume_prefixes | map('regex_escape') | join('|') }})' |
+  while read -r volume; do
+    docker volume inspect -f '{{ "{{" }}.Mountpoint{{ "}}" }}' "$volume"
+  done |
+  sort -u
+)
+
+for path in "${volume_paths[@]}"; do
+  if [[ -d "$path" ]]; then
+    mkdir -p "$restore_root/volumes"
+    safe_name=$(echo "$path" | tr / _)
+    mv "$path" "$restore_root/volumes/$safe_name"
+    mkdir -p "$path"
+  fi
+done
+
+cd /
+{{ bbclient_all | default('/opt/bbclient-' ~ sentry_backup_name ~ '/bin/bbclient-all') }} extract "::$archive"
+
+cd "$sentry_home"
+docker compose up -d --wait
+curl -fsS http://127.0.0.1:9000/_health/ >/dev/null
+
+echo "Sentry restored from $archive. Previous data moved to $restore_root"

--- a/devops/roles/icos.sentry/templates/sentry-borg-restore
+++ b/devops/roles/icos.sentry/templates/sentry-borg-restore
@@ -24,7 +24,6 @@ fi
 # Move existing Sentry install and Docker volume payloads out of the way before
 # extracting. They are kept for manual rollback until the restore is verified.
 if [[ -e "$sentry_home" ]]; then
-  mkdir -p "$restore_root/opt"
   mv "$sentry_home" "$restore_root/sentry-self-hosted.previous"
 fi
 
@@ -51,6 +50,6 @@ cd /
 
 cd "$sentry_home"
 docker compose up -d --wait
-curl -fsS http://127.0.0.1:9000/_health/ >/dev/null
+curl -fsS {{ sentry_health_url | quote }} >/dev/null
 
 echo "Sentry restored from $archive. Previous data moved to $restore_root"

--- a/devops/vm-fsicos4-sentry.yml
+++ b/devops/vm-fsicos4-sentry.yml
@@ -1,0 +1,43 @@
+- hosts: fsicos4
+  roles:
+    - role: icos.pve_server
+      tags: pve_server
+  tasks:
+    - name: Synchronize VM SSH port forwarding
+      tags: guest
+      command: icos-auto-dnat run
+      register: _sentry_auto_dnat
+      changed_when: >-
+        'adding port' in _sentry_auto_dnat.stdout or
+        'removing rule' in _sentry_auto_dnat.stdout
+
+- hosts: sentry
+  vars:
+    sentry_url: https://sentry.icos-cp.eu
+    sentry_version: "26.2.1"
+    sentry_backup_name: sentry
+    sentry_backup_remotes:
+      - icos1
+  roles:
+    - role: icos.pve_guest
+      tags: guest
+
+    - role: icos.docker2
+      tags: docker
+      # Sentry is large; keep images/volumes unless cleanup is explicitly run.
+      docker_periodic_cleanup: false
+
+    - role: icos.nebula
+      tags: nebula
+
+    - role: icos.sentry
+      tags: sentry
+
+  tasks:
+    - name: Install Sentry Borg backup
+      tags: backup
+      include_role:
+        name: icos.sentry
+        tasks_from: backup
+        apply:
+          tags: backup

--- a/devops/vm-fsicos4-sentry.yml
+++ b/devops/vm-fsicos4-sentry.yml
@@ -12,6 +12,7 @@
         'removing rule' in _sentry_auto_dnat.stdout
 
 - hosts: sentry
+  become: true
   vars:
     sentry_url: https://sentry.icos-cp.eu
     sentry_version: "26.2.1"


### PR DESCRIPTION
The Sentry VM was created manually a while ago and this playbook should match the current configuration if we would need to re-deploy it. This PR was also the opportunity to properly integrate with Borg to have daily backups and a way to restore them when needed.