### PR TITLE
Add config for the eric-forum.eu WP container

### DIFF
--- a/devops/files/wordpress.conf
+++ b/devops/files/wordpress.conf
@@ -1,14 +1,32 @@
+limit_req_zone $binary_remote_addr zone={{ wp_site_rate_zone }}:10m rate=5r/m;
+
 server {
-    listen       443 ssl;
-    server_name  {{ wordpress_domains | join(" ") }};
+    listen 443 ssl;
+    server_name {{ wp_site_domains | join(" ") }};
 
     ssl_certificate /etc/letsencrypt/live/wordpress/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/wordpress/privkey.pem;
     client_max_body_size 100M;
-    access_log /var/log/nginx/wordpress.log;
+    access_log /var/log/nginx/{{ wp_site_log }}.log;
+
+    # Block xmlrpc.php entirely — common brute force vector
+    location = /xmlrpc.php {
+        return 444;
+    }
+
+    # Rate limit WordPress login page
+    location = /wp-login.php {
+        limit_req zone={{ wp_site_rate_zone }} burst=3 nodelay;
+        proxy_pass http://{{ wp_site_upstream }}:80;
+        proxy_read_timeout 180;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto "https";
+    }
 
     location / {
-        proxy_pass http://wordpress.lxd:80;
+        proxy_pass http://{{ wp_site_upstream }}:80;
         proxy_read_timeout 180;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -19,7 +37,6 @@ server {
 
 server {
     listen 80;
-    server_name  {{ wordpress_domains | join(" ") }};
-
+    server_name {{ wp_site_domains | join(" ") }};
     return 301 https://$host$request_uri;
 }

--- a/devops/files/wordpress.conf
+++ b/devops/files/wordpress.conf
@@ -16,7 +16,7 @@ server {
 
     # Rate limit WordPress login page
     location = /wp-login.php {
-        limit_req zone={{ wp_site_rate_zone }} burst=3 nodelay;
+        limit_req zone={{ wp_site_rate_zone }} burst=5 nodelay;
         proxy_pass http://{{ wp_site_upstream }}:80;
         proxy_read_timeout 180;
         proxy_set_header Host $host;

--- a/devops/library/lxd_container.py
+++ b/devops/library/lxd_container.py
@@ -478,12 +478,11 @@ class LXDContainerManagement(object):
 
         self.type = self.module.params['type']
 
-        # LXD Rest API provides additional endpoints for creating containers and virtual-machines.
-        self.api_endpoint = None
-        if self.type == 'container':
-            self.api_endpoint = '/1.0/containers'
-        elif self.type == 'virtual-machine':
-            self.api_endpoint = '/1.0/virtual-machines'
+        # LXD Rest API historically provided separate /containers and
+        # /virtual-machines endpoints. Newer LXD versions use /instances for
+        # both; the old endpoints can return 404 even though the instance
+        # exists. Use the common endpoint so existing containers are found.
+        self.api_endpoint = '/1.0/instances'
 
         self.key_file = self.module.params.get('client_key')
         if self.key_file is None:

--- a/devops/production.inventory/hosts.yml
+++ b/devops/production.inventory/hosts.yml
@@ -125,6 +125,8 @@ all:
           ansible_port: 60585
         wordpress:
           ansible_port: 60552
+        wordpress-eric-forum:
+          ansible_port: 60553
         cities:
           ansible_port: 60565
 

--- a/devops/roles/icos.lxd_forward/tasks/main.yml
+++ b/devops/roles/icos.lxd_forward/tasks/main.yml
@@ -1,13 +1,13 @@
 - name: Add iptables rule to forward lxd_forward_port
   tags: iptables
   iptables_raw:
-    name: "forward_ssh_to_{{ lxd_forward_name }}"
+    name: "forward_ssh_to_{{ lxd_forward_name | replace('-', '_') }}"
     table: nat
     rules: >-
       -A PREROUTING -p tcp
       --dport {{ lxd_forward_port }}
       -j DNAT --to-destination {{ lxd_forward_ip }}:22
-  when: lxd_forward_port
+  when: lxd_forward_port is defined and lxd_forward_port | int > 0
 
 - name: Modify /etc/hosts to add lxd_forward_name.lxd
   lineinfile:

--- a/devops/roles/icos.lxd_vm/defaults/main.yml
+++ b/devops/roles/icos.lxd_vm/defaults/main.yml
@@ -41,7 +41,7 @@ lxd_vm_ubuntu_version: "22.04"
 lxd_source:
   type: image
   mode: pull
-  server: https://cloud-images.ubuntu.com/releases
+  server: https://cloud-images.ubuntu.com/releases/
   protocol: simplestreams
   alias: "{{ lxd_vm_ubuntu_version }}"
 

--- a/devops/roles/icos.lxd_vm/tasks/main.yml
+++ b/devops/roles/icos.lxd_vm/tasks/main.yml
@@ -29,6 +29,12 @@
     name: "{{ lxd_vm_name }}"
   register: _static_ip_info
 
+- name: Check whether container exists
+  command: lxc info {{ lxd_vm_name }}
+  register: _lxd_container_info
+  failed_when: false
+  changed_when: false
+
 - name: Create container
   lxd_container:
     name: "{{ lxd_vm_name }}"
@@ -41,6 +47,20 @@
     wait_for_ipv4_interfaces: eth0
     timeout: 600
   register: _lxd
+  when: _lxd_container_info.rc != 0
+
+- name: Configure existing container
+  lxd_container:
+    name: "{{ lxd_vm_name }}"
+    state: started
+    profiles: "{{ __lxd_vm_profiles }}"
+    config: "{{ __lxd_vm_config }}"
+    devices: "{{ __lxd_vm_devices }}"
+    wait_for_ipv4_addresses: true
+    wait_for_ipv4_interfaces: eth0
+    timeout: 600
+  register: _lxd
+  when: _lxd_container_info.rc == 0
 
 - name: Set static lxd IP
   lxd_static_ip:

--- a/devops/roles/icos.lxd_vm/tasks/main.yml
+++ b/devops/roles/icos.lxd_vm/tasks/main.yml
@@ -30,7 +30,7 @@
   register: _static_ip_info
 
 - name: Check whether container exists
-  command: lxc info {{ lxd_vm_name }}
+  command: lxc info {{ lxd_vm_name | quote }}
   register: _lxd_container_info
   failed_when: false
   changed_when: false
@@ -70,7 +70,7 @@
 - name: Extract host_ecdsa_key from the VM
   check_mode: False
   command: >-
-    lxc exec {{ lxd_vm_name }}
+    lxc exec {{ lxd_vm_name | quote }}
     awk '{print $1, $2}' /etc/ssh/ssh_host_ecdsa_key.pub
   register: _key
   changed_when: no
@@ -80,7 +80,7 @@
 
 - name: Inject ssh root keys into the VM
   command: >-
-    lxc exec {{ lxd_vm_name }} --
+    lxc exec {{ lxd_vm_name | quote }} --
     bash -c "[ -s '{{ file }}' ] || {
                echo '{{ keys }}' >> {{ file }};
                echo added;

--- a/devops/roles/icos.lxd_vm/vars/ext4.yml
+++ b/devops/roles/icos.lxd_vm/vars/ext4.yml
@@ -21,4 +21,4 @@ __docker_config: >-
   {% else %}{}{% endif -%}
 
 lxd_vm_default_config: >-
-  {{ __base_config | combine(__docker_config) }}
+  {{ __base_config | combine(__docker_config | from_yaml) }}

--- a/devops/roles/icos.lxd_vm/vars/zfs.yml
+++ b/devops/roles/icos.lxd_vm/vars/zfs.yml
@@ -16,7 +16,7 @@ __docker_device: >-
   {% else -%}{}{% endif -%}
 
 lxd_vm_default_devices: >-
-  {{ __root_device | combine(__docker_device) }}
+  {{ __root_device | combine(__docker_device | from_yaml) }}
 
 
 # PROFILES
@@ -33,4 +33,4 @@ __docker_config: >-
   {% else %}{}{% endif -%}
 
 lxd_vm_default_config: >-
-  {{ __base_config | combine(__docker_config) }}
+  {{ __base_config | combine(__docker_config | from_yaml) }}

--- a/devops/vm-wordpress.yml
+++ b/devops/vm-wordpress.yml
@@ -2,8 +2,6 @@
   vars:
     wordpress_domains:
       - www.ingos-infrastructure.eu
-      - eric-forum.eu
-      - www.eric-forum.eu
       - www.icos-summerschool.eu
       - www.envriplus.eu
       - avengers-project.eu
@@ -12,6 +10,10 @@
       - www.george-project.eu
       - kadi-project.eu
       - www.kadi-project.eu
+    wordpress_eric_forum_domains:
+      - eric-forum.eu
+      - www.eric-forum.eu
+    wordpress_cert_domains: "{{ wordpress_domains + wordpress_eric_forum_domains }}"
   roles:
     - role: icos.lxd_vm
       tags: lxd
@@ -24,15 +26,37 @@
     - role: icos.certbot2
       tags: cert
       certbot_name: wordpress
-      certbot_domains: "{{ wordpress_domains }}"
+      certbot_domains: "{{ wordpress_cert_domains }}"
 
     - role: icos.nginxsite
       tags: nginx
       nginxsite_name: wordpress
       nginxsite_file: files/wordpress.conf
+      wp_site_domains: "{{ wordpress_domains }}"
+      wp_site_upstream: wordpress.lxd
+      wp_site_log: wordpress
+      wp_site_rate_zone: wp_login
+
+    - role: icos.lxd_vm
+      tags: lxd
+      lxd_vm_name: wordpress-eric-forum
+      lxd_vm_root_size: "500GB"
+      lxd_vm_ubuntu_version: "24.04"
+      lxd_vm_config:
+        limits.cpu: "4"
+        limits.memory: "8GB"
+
+    - role: icos.nginxsite
+      tags: nginx
+      nginxsite_name: eric-forum
+      nginxsite_file: files/wordpress.conf
+      wp_site_domains: "{{ wordpress_eric_forum_domains }}"
+      wp_site_upstream: wordpress-eric-forum.lxd
+      wp_site_log: eric-forum
+      wp_site_rate_zone: wp_login_ef
 
 
-- hosts: wordpress
+- hosts: wordpress,wordpress-eric-forum
   roles:
     - role: icos.lxd_guest
       tags: guest


### PR DESCRIPTION
An update to WordPress playbook deploying LXD containers on fsicos2 to make it possible to deploy separate containers for some websites. The eric-forum.eu used to run in the `wordpress.lxd` and is now separated for better isolation and to give access to external maintainers.