### PR TITLE
Log SPARQL queries from meta

### DIFF
--- a/devops/roles/icos.cpmeta/tasks/setup.yml
+++ b/devops/roles/icos.cpmeta/tasks/setup.yml
@@ -27,6 +27,14 @@
     group: "{{ cpmeta_user }}"
     recurse: yes
 
+- name: Create cpmeta log directory
+  file:
+    path: /var/log/cpmeta
+    state: directory
+    owner: "{{ cpmeta_user }}"
+    group: "{{ cpmeta_user }}"
+    mode: "0755"
+
 - name: Add systemd service
   template:
     src: cpmeta.service

--- a/devops/roles/icos.cpmeta/templates/cpmeta.conf
+++ b/devops/roles/icos.cpmeta/templates/cpmeta.conf
@@ -37,8 +37,6 @@ server {
 
         proxy_buffer_size 8k;
         proxy_read_timeout 300s;
-
-        access_log /var/log/nginx/sparql.log postdata;
     }
 }
 

--- a/devops/roles/icos.cpmeta/templates/cpmeta.service
+++ b/devops/roles/icos.cpmeta/templates/cpmeta.service
@@ -9,6 +9,7 @@ ExecStart={{ java_path }} -jar cpmeta.jar
 Restart=always
 RestartSec=30
 WorkingDirectory=/home/{{ cpmeta_user }}
+Environment=SPARQL_QUERY_LOG_FILE=/var/log/cpmeta/sparql-query.log
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Let meta log SPARQL queries instead of nginx. This allows to better keep track of the queries by logging different stages and adding identifiers to these logs.

The meta log changes are done in https://github.com/ICOS-Carbon-Portal/meta/pull/371