### PR TITLE
[icos.stiltweb] Separate local and application config files

### DIFF
--- a/devops/roles/icos.stiltweb/tasks/deploy.yml
+++ b/devops/roles/icos.stiltweb/tasks/deploy.yml
@@ -4,11 +4,17 @@
     dest: /etc/systemd/system/stiltweb.service
   register: _service
 
-- name: Create configuration file
+- name: Create local configuration file
   template:
     dest: "{{ stiltweb_home }}/local.conf"
     src: local.conf
-  register: _config
+  register: _config_local
+
+- name: Create application configuration file
+  template:
+    dest: "{{ stiltweb_home }}/application.conf"
+    src: application.conf
+  register: _config_app
 
 - name: Copy jarfile
   when: stiltweb_jar_file is defined
@@ -32,7 +38,7 @@
     enabled: yes
     daemon-reload: "{{ 'yes' if _service.changed else 'no' }}"
     state: >-
-      {{ 'restarted' if _jarfile.changed or _config.changed else 'started' }}
+      {{ 'restarted' if _jarfile.changed or _config_local.changed or _config_app.changed else 'started' }}
 
 - name: Check that the service responds
   uri:

--- a/devops/roles/icos.stiltweb/templates/application.conf
+++ b/devops/roles/icos.stiltweb/templates/application.conf
@@ -1,0 +1,1 @@
+{% include 'roles/icos.cpauth/templates/application_auth_views.conf' %}

--- a/devops/roles/icos.stiltweb/templates/local.conf
+++ b/devops/roles/icos.stiltweb/templates/local.conf
@@ -7,5 +7,3 @@ stiltweb{
 	admins = ["ute.karstens@nateko.lu.se", "oleg.mirzov@nateko.lu.se"]
 	matomo.authToken = "{{ stiltweb_matomo_token }}"
 }
-
-{% include 'roles/icos.cpauth/templates/application_auth_views.conf' %}


### PR DESCRIPTION
The viewsCore variables have to be `application.conf` to be read correctly, but were previously populating into `local.conf`. This change separates out the `local.conf` and `application.conf` variables.

Longer term we should switch `stiltweb` to using only an `application.conf` file, but right now, it doesn't respect the local configuration changes in an `application.conf` file.