### PR TITLE
Update DOI app nginx caching configuration

### DIFF
--- a/devops/roles/icos.doi/templates/doi.conf
+++ b/devops/roles/icos.doi/templates/doi.conf
@@ -10,12 +10,24 @@ server {
 
     access_log /var/log/nginx/doi.log;
 
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto "https";
+
+    location /api/ {
+        proxy_pass http://{{ doi_host }}:{{ doi_port }};
+        add_header Cache-Control "no-store" always;
+    }
+
+    location ~ ^/(doi\.[0-9a-f]+\.js|styles\.[0-9a-f]+\.css)$ {
+        proxy_pass http://{{ doi_host }}:{{ doi_port }};
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+    }
+
     location / {
         proxy_pass http://{{ doi_host }}:{{ doi_port }};
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto "https";
+        add_header Cache-Control "no-cache" always;
     }
 }
 


### PR DESCRIPTION
This is the nginx configuration changes to enable assets caching for the DOI app. The full description of the change can be found at https://github.com/ICOS-Carbon-Portal/doi/pull/40.