### PR TITLE
Configure caddy for core deployment on fs4 test VM

### DIFF
--- a/devops/core.yml
+++ b/devops/core.yml
@@ -1,5 +1,22 @@
 - hosts: core_server
   tasks:
+    - name: Setup core caddy proxy
+      tags:
+        - proxy
+        - caddy
+        - core_caddy_proxy
+        - cpmeta_proxy
+        - cpdata_proxy
+        - cpauth_proxy
+        - restheart_proxy
+        - doi_proxy
+      import_role:
+        name: icos.caddy
+      vars:
+        caddy_name: "{{ core_caddy_name }}"
+        caddy_conf: "{{ core_caddy_conf }}"
+      when: core_proxy | default('nginx') == 'caddy'
+
     - name: Setup cpmeta proxy
       tags:
         - proxy
@@ -7,6 +24,7 @@
       import_role:
         name: icos.cpmeta
         tasks_from: proxy.yml
+      when: core_proxy | default('nginx') == 'nginx'
 
     - name: Setup cpdata proxy
       tags:
@@ -15,6 +33,7 @@
       import_role:
         name: icos.cpdata
         tasks_from: proxy.yml
+      when: core_proxy | default('nginx') == 'nginx'
 
     - name: Setup cpauth proxy
       tags:
@@ -23,7 +42,9 @@
       import_role:
         name: icos.cpauth
         tasks_from: proxy.yml
-      when: cpauth_domains is defined
+      when:
+        - core_proxy | default('nginx') == 'nginx'
+        - cpauth_domains is defined
 
     - name: Setup restheart proxy
       tags:
@@ -32,6 +53,7 @@
       import_role:
         name: icos.restheart
         tasks_from: proxy.yml
+      when: core_proxy | default('nginx') == 'nginx'
 
     - name: Setup doi proxy
       tags:
@@ -40,7 +62,9 @@
       import_role:
         name: icos.doi
         tasks_from: proxy.yml
-      when: doi_certbot_name is defined
+      when:
+        - core_proxy | default('nginx') == 'nginx'
+        - doi_certbot_name is defined
 
 - hosts: core_host
   pre_tasks:

--- a/devops/test-fs4.inventory/core.yml
+++ b/devops/test-fs4.inventory/core.yml
@@ -17,6 +17,8 @@ all:
     cpdata_sites_domain: data.fs4vm.fielsites.se
     cpdata_cities_domain: citydata.fs4vm.icos-cp.eu
 
+    cpmeta_virtuoso_domain: meta-virtuoso.fs4vm.icos-cp.eu
+
     cpauth_domains:
       - "{{ cpauth_icos_domain }}"
 
@@ -102,11 +104,29 @@ all:
     core_server:
       hosts:
         fsicos4:
-          ansible_port: 60608
 
       vars:
-        coreapp_httpproxy_host: fsicos4
+        core_proxy: caddy
+        coreapp_httpproxy_host: staging-test
         coreapp_host_ip: "{{ fsicos4_ip }}"
+
+        core_caddy_name: core-test-fs4
+        core_caddy_conf: |
+          {{ cpmeta_icos_domain }} {
+                  reverse_proxy {{ coreapp_httpproxy_host }}:9094
+          }
+
+          {{ cpmeta_virtuoso_domain }} {
+                  reverse_proxy {{ coreapp_httpproxy_host }}:9095
+          }
+
+          {{ cpauth_icos_domain }} {
+                  reverse_proxy {{ coreapp_httpproxy_host }}:8080
+          }
+
+          {{ cpdata_icos_domain }} {
+                  reverse_proxy {{ coreapp_httpproxy_host }}:9011
+          }
 
         # cpmeta - proxy
         cpmeta_nginxsite_name: cpmeta-test
@@ -121,7 +141,7 @@ all:
         cpauth_nginxsite_name: cpauth-test
 
         # restheart - proxy
-        restheart_host: vm_fsicos4_test
+        restheart_host: "{{ coreapp_httpproxy_host }}"
         restheart_nginxsite_name: restheart-test
         restheart_certbot_name: restheart-test
         restheart_domains:


### PR DESCRIPTION
Use caddy for the test-fs4 VM and keep nginx as the default for other environments.